### PR TITLE
Now serving robots.txt and Twitter meta tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ file(GLOB STATIC_IMG
   "src/www/img/**"
 )
 file(COPY "src/www/favicon.ico" DESTINATION "${CMAKE_BINARY_DIR}/static/")
+file(COPY "src/www/robots.txt" DESTINATION "${CMAKE_BINARY_DIR}/static/")
 file(COPY ${STATIC_IMG} DESTINATION "${CMAKE_BINARY_DIR}/static/img/")
 
 target_include_directories(CockatriceTournamentBot PUBLIC

--- a/src/api_server.c
+++ b/src/api_server.c
@@ -703,7 +703,10 @@ static void eventHandler(struct mg_connection *c,
 #endif
             if (mg_http_match_uri(hm, "/favicon.ico")) {
                 struct mg_http_serve_opts opts = {.mime_types = "ico=image/x-icon"};
-                mg_http_serve_file(c, hm, "static/favicon.ico", &opts);  // Send file
+                mg_http_serve_file(c, hm, "static/favicon.ico", &opts);  // Send favicon
+            } else if (mg_http_match_uri(hm, "/robots.txt")) {
+                struct mg_http_serve_opts opts = {.mime_types = "txt=text/plain"};
+                mg_http_serve_file(c, hm, "static/robots.txt", &opts);  // Send robots
             } else if (mg_http_match_uri(hm, "/img/**")) {
                 struct mg_http_serve_opts opts = {.root_dir = "static"};   // Serve the static directory
                 mg_http_serve_dir(c, hm, &opts);

--- a/src/www/api_faq.html
+++ b/src/www/api_faq.html
@@ -2,12 +2,17 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title>FAQ - Monarch Bot</title>        
+        <title>FAQ - Monarch Bot</title>    
+        <meta name="description" content="The FAQ for commonly asked questions about Monarch Bot.">        
         <meta property="og:title" content="FAQ - Monarch Bot" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://tricebot.co.uk" />
         <meta property="og:image" content="https://tricebot.co.uk/img/logo.png" />
-        <meta property="og:description" content="Monarch Bot is a free and open source software to make hosting tournaments on Cockatrice easier." />
+        <meta property="og:description" content="The FAQ for commonly asked questions about Monarch Bot." />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="FAQ - Monarch Bot" />
+        <meta name="twitter:description" content="The FAQ for commonly asked questions about Monarch Bot." />
+        <meta name="twitter:image" content="https://tricebot.co.uk/img/logo.png" />
         <meta name="theme-color" content="#004B4B">
         <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/src/www/api_help.html
+++ b/src/www/api_help.html
@@ -2,12 +2,17 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title>API Documentation - Monarch Bot</title>        
+        <title>API Documentation - Monarch Bot</title>      
+        <meta name="description" content="The API reference for the Monarch Bot.">       
         <meta property="og:title" content="API Documentation - Monarch Bot" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://tricebot.co.uk" />
         <meta property="og:image" content="https://tricebot.co.uk/img/logo.png" />
-        <meta property="og:description" content="Monarch Bot is a free and open source software to make hosting tournaments on Cockatrice easier." />
+        <meta property="og:description" content="The API reference for the Monarch Bot." />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="API Documentation - Monarch Bot" />
+        <meta name="twitter:description" content="The API reference for the Monarch Bot." />
+        <meta name="twitter:image" content="https://tricebot.co.uk/img/logo.png" />
         <meta name="theme-color" content="#004B4B">
         <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -2,12 +2,17 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title>Home - Monarch Bot</title>        
+        <title>Home - Monarch Bot</title>   
+        <meta name="description" content="Monarch Bot is a free and open source software to make hosting tournaments on Cockatrice easier.">     
         <meta property="og:title" content="Home - Monarch Bot" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://tricebot.co.uk" />
         <meta property="og:image" content="https://tricebot.co.uk/img/logo.png" />
         <meta property="og:description" content="Monarch Bot is a free and open source software to make hosting tournaments on Cockatrice easier." />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="Home - Monarch Bot" />
+        <meta name="twitter:description" content="Monarch Bot is a free and open source software to make hosting tournaments on Cockatrice easier." />
+        <meta name="twitter:image" content="https://tricebot.co.uk/img/logo.png" />
         <meta name="theme-color" content="#004B4B">
         <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/src/www/robots.txt
+++ b/src/www/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Allow: /
+Disallow:

--- a/src/www/robots.txt
+++ b/src/www/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
Things added:
- API server now serves a `robots.txt` file, that currently allows crawling of everything atm
- Twitter Metatags added to static files as a test